### PR TITLE
Korrektur Filter-Verzeichnis und Entfernung hardkodierter Pfade

### DIFF
--- a/components/components/filter/CMakeLists.txt
+++ b/components/components/filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "filter.c" "firfilter.c" "iirfilter.c"
+idf_component_register(SRCS "filter.c" "firfilter.c" "iirfilter.c" "dcfilter.c" "lpfilter.c" "meanfilter.c"
                     INCLUDE_DIRS "include"
                     REQUIRES ringbuffer)
 

--- a/poxi/CMakeLists.txt
+++ b/poxi/CMakeLists.txt
@@ -3,10 +3,10 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(EXTRA_COMPONENT_DIRS 
-  "C:/Users/prits/git/embedded-systems-mit-risc-v/components/components/graphics" 
-  "C:/Users/prits/git/embedded-systems-mit-risc-v/components/components/pushbtn"
-  "C:/Users/prits/git/embedded-systems-mit-risc-v/components/components/max3010x"
-  "C:/Users/prits/git/embedded-systems-mit-risc-v/components/components/filter"
-  "C:/Users/prits/git/embedded-systems-mit-risc-v/components/components/ringbuffer")
+	"${CMAKE_SOURCE_DIR}/../components/components/graphics" 
+	"${CMAKE_SOURCE_DIR}/../components/components/pushbtn"
+	"${CMAKE_SOURCE_DIR}/../components/components/max3010x"
+	"${CMAKE_SOURCE_DIR}/../components/components/filter"
+	"${CMAKE_SOURCE_DIR}/../components/components/ringbuffer")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(app-template)

--- a/poxi/main/CMakeLists.txt
+++ b/poxi/main/CMakeLists.txt
@@ -2,7 +2,7 @@
 # for more information about component CMakeLists.txt files.
 
 idf_component_register(
-    SRCS main.c pulseoxi.c meanfilter.c lpfilter.c dcfilter.c blehrdevice.c staticwifi.c mqtt.c sendpacket.c webserver.c provisioning.c # list the source files of this component
+    SRCS main.c pulseoxi.c blehrdevice.c staticwifi.c mqtt.c sendpacket.c webserver.c provisioning.c # list the source files of this component
     INCLUDE_DIRS        # optional, add here public include directories
     PRIV_INCLUDE_DIRS   # optional, add here private include directories
     REQUIRES            # optional, list the public requirements (component names)


### PR DESCRIPTION
- Filter (Header und Implementierung) aus `poxi`-Projekt in `components`-Projekt verschoben
- Hartkodierte Pfade zum `components`-Projekt in `poxi/CMakeLists.txt` ersetzt durch relative Pfade
  - dabei wird `${CMAKE_SOURCE_DIR}` verwendet, um absoluten Pfade des `poxi`-Projektes zu bestimmen; es wird erwartet, dass sich das `components`-Verzeichnis in demselben Verzeichnis befindet wie das `poxi`-Verzeichnis.